### PR TITLE
add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "q": "^1.0.1",
     "ramda": "^0.1.3",
     "request": "^2.35.0",
+    "simple-rate-limiter": "^0.2.3",
     "thunkify": "^2.1.1",
     "traverse": "^0.6.6",
     "xml2js": "^0.4.2"


### PR DESCRIPTION
Thanks for the cool API! 

This PR just adds a missing dependency. Without it running `npm start` on the current `master` branch gives the following error:

```
$ npm start

> collections-api@0.0.9 start /Users/mathisonian/projects/collections-api
> coffee --nodejs --harmony server.coffee

Error: Cannot find module 'simple-rate-limiter'
  at Function.Module._resolveFilename (module.js:336:15)
  at Function.Module._load (module.js:278:25)
  at Module.require (module.js:365:17)
  at require (module.js:384:17)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/libs/getEndpoint.js:6:15)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/libs/getEndpoint.js:31:4)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (/Users/mathisonian/projects/collections-api/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
  at Function.Module._load (module.js:310:12)
  at Module.require (module.js:365:17)
  at require (module.js:384:17)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/libs/getIds.js:5:17)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/libs/getIds.js:95:4)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (/Users/mathisonian/projects/collections-api/node_modules/coffee-script/lib/coffee-script/register.js:45:36)
  at Function.Module._load (module.js:310:12)
  at Module.require (module.js:365:17)
  at require (module.js:384:17)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/server.coffee:12:10)
  at Object.<anonymous> (/Users/mathisonian/projects/collections-api/server.coffee:1:1)
  at Module._compile (module.js:460:26)
```
